### PR TITLE
Fix IdentityUser build error

### DIFF
--- a/src/Capco.Domain/Capco.Domain.csproj
+++ b/src/Capco.Domain/Capco.Domain.csproj
@@ -5,6 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- replace the legacy Microsoft.AspNetCore.Identity package reference in Capco.Domain
- add a framework reference to Microsoft.AspNetCore.App so IdentityUser is available when targeting .NET 8

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e48603a84c8323a594222eab1ac7f8