### PR TITLE
Add Identity EF Core dependency to data project

### DIFF
--- a/src/Capco.Data/Capco.Data.csproj
+++ b/src/Capco.Data/Capco.Data.csproj
@@ -8,9 +8,10 @@
     <ProjectReference Include="../Capco.Domain/Capco.Domain.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add the Microsoft.AspNetCore.Identity.EntityFrameworkCore package to the data project to provide IdentityDbContext
- ensure required EF Core packages are referenced explicitly

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e487546ef48323bc27817335550e72