### PR TITLE
Fix cart namespace conflict and add Stripe dependency

### DIFF
--- a/src/Capco.Services/Capco.Services.csproj
+++ b/src/Capco.Services/Capco.Services.csproj
@@ -8,4 +8,7 @@
     <ProjectReference Include="../Capco.Domain/Capco.Domain.csproj" />
     <ProjectReference Include="../Capco.Data/Capco.Data.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Stripe.net" Version="42.23.0" />
+  </ItemGroup>
 </Project>

--- a/src/Capco.Services/Cart/CartService.cs
+++ b/src/Capco.Services/Cart/CartService.cs
@@ -2,7 +2,7 @@ using Capco.Data;
 using Capco.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
-namespace Capco.Services.Cart;
+namespace Capco.Services.Carts;
 
 public class CartService : ICartService
 {

--- a/src/Capco.Services/Cart/ICartService.cs
+++ b/src/Capco.Services/Cart/ICartService.cs
@@ -1,6 +1,6 @@
 using Capco.Domain.Entities;
 
-namespace Capco.Services.Cart;
+namespace Capco.Services.Carts;
 
 public interface ICartService
 {

--- a/src/Capco.Services/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Capco.Services/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-using Capco.Services.Cart;
+using Capco.Services.Carts;
 using Capco.Services.Catalog;
 using Capco.Services.Email;
 using Capco.Services.Inventory;

--- a/src/Capco.Web/Controllers/CartController.cs
+++ b/src/Capco.Web/Controllers/CartController.cs
@@ -1,5 +1,5 @@
 using Capco.Domain.Entities;
-using Capco.Services.Cart;
+using Capco.Services.Carts;
 using Capco.Services.Pricing;
 using Capco.Web.Models;
 using Microsoft.AspNetCore.Http;

--- a/src/Capco.Web/Controllers/CheckoutController.cs
+++ b/src/Capco.Web/Controllers/CheckoutController.cs
@@ -1,5 +1,5 @@
 using Capco.Domain.Entities;
-using Capco.Services.Cart;
+using Capco.Services.Carts;
 using Capco.Services.Orders;
 using Capco.Services.Payments;
 using Capco.Services.Pricing;

--- a/src/Capco.Web/Controllers/ProductsController.cs
+++ b/src/Capco.Web/Controllers/ProductsController.cs
@@ -1,6 +1,6 @@
 using Capco.Domain.Entities;
 using Capco.Services.Catalog;
-using Capco.Services.Cart;
+using Capco.Services.Carts;
 using Capco.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/tests/Capco.Tests/Services/CartServiceTests.cs
+++ b/tests/Capco.Tests/Services/CartServiceTests.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Capco.Domain.Entities;
-using Capco.Services.Cart;
+using Capco.Services.Carts;
 using Capco.Services.Pricing;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- rename the cart service namespace to avoid conflicts with the Cart entity type
- update controllers, tests, and service registration to consume the new namespace
- add the Stripe.net package reference required by the payment service implementation

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e487fb03588323a3ea30f4e6361f54