### PR TITLE
Fix EF Core developer exception extensions

### DIFF
--- a/src/Capco.Web/Capco.Web.csproj
+++ b/src/Capco.Web/Capco.Web.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Stripe.net" Version="44.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Capco.Web/Program.cs
+++ b/src/Capco.Web/Program.cs
@@ -3,6 +3,7 @@ using Capco.Data.Seed;
 using Capco.Domain.Identity;
 using Capco.Services.Extensions;
 using Capco.Services.Payments;
+using Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 


### PR DESCRIPTION
## Summary
- add the Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore package so developer exception extensions are available
- import the diagnostics namespace in Program.cs so the extension methods resolve

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e48a4bf16c8323bf3098e8e6784bfb