### PR TITLE
Fix test project dependencies and analyzer warning

### DIFF
--- a/tests/Capco.Tests/Capco.Tests.csproj
+++ b/tests/Capco.Tests/Capco.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Capco.Services/Capco.Services.csproj" />

--- a/tests/Capco.Tests/Services/OrderServiceTests.cs
+++ b/tests/Capco.Tests/Services/OrderServiceTests.cs
@@ -35,7 +35,7 @@ public class OrderServiceTests
         var order = await service.CreateOrderFromCartAsync(cart, new Address { Line1 = "1 Main", City = "East Hanover", State = "NJ", Zip = "07936", Country = "USA", Type = "Shipping" }, null, "guest@example.com");
 
         Assert.NotNull(order.OrderNumber);
-        Assert.Equal(1, order.Items.Count);
+        Assert.Single(order.Items);
         Assert.Equal("pending", order.Status);
     }
 }


### PR DESCRIPTION
## Summary
- add the Entity Framework Core InMemory provider to the test project so the in-memory context configuration compiles
- update the order service test to use Assert.Single to satisfy the xUnit analyzer

## Testing
- `dotnet test tests/Capco.Tests/Capco.Tests.csproj` *(fails: `dotnet` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e48adcb94c832396b51b1c46ea736f