### PR TITLE
Trust SQL Server certificate in local config

### DIFF
--- a/src/Capco.Web/appsettings.json
+++ b/src/Capco.Web/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=WINDESKTOP\\SQLEXPRESS;Database=CapcoJordan;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=WINDESKTOP\\SQLEXPRESS;Database=CapcoJordan;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
   },
   "Stripe": {
     "SecretKey": "sk_test_XXXXXXXXXXXXXXXXXXXX",


### PR DESCRIPTION
## Summary
- trust the SQL Server certificate in the default connection string to avoid SSL login failures

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e531aff3a483238e6036ed7f59be8c