### PR TITLE
Restore SQL Server setup with dedicated login

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,19 +13,19 @@ Capco Confectionery's e-commerce experience built with ASP.NET Core MVC, Entity 
 
 1. Copy `src/Capco.Web/appsettings.Development.json.sample` to `src/Capco.Web/appsettings.Development.json`.
 2. Update the following keys:
-   - `ConnectionStrings:DefaultConnection` – SQL Server connection string.
+   - `ConnectionStrings:DefaultConnection` – SQL Server connection string. The provided sample uses the `capco_app` SQL login created by the install script.
    - `Stripe:SecretKey` and `Stripe:PublishableKey` – Stripe test keys.
    - `Smtp:*` – Optional SMTP settings for order confirmation emails.
 
 ## Database Provisioning
 
-The application expects the SQL Server database to be pre-provisioned. Run the install script to rebuild the schema and seed data on `WINDESKTOP\\SQLEXPRESS`:
+The application expects the SQL Server database to be pre-provisioned. Run the install script to rebuild the schema, seed data, and create a dedicated SQL login on `WINDESKTOP\\SQLEXPRESS`:
 
 ```powershell
 sqlcmd -S WINDESKTOP\\SQLEXPRESS -i docs/sql/Install_WINDESKTOP_SQLEXPRESS.sql
 ```
 
-Update `appsettings.Development.json` if you need a different server name.
+Update `appsettings.Development.json` if you need a different server name or credentials.
 
 ## Running the Solution
 

--- a/docs/sql/Install_WINDESKTOP_SQLEXPRESS.sql
+++ b/docs/sql/Install_WINDESKTOP_SQLEXPRESS.sql
@@ -14,13 +14,37 @@ BEGIN
 END
 GO
 
+IF EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'capco_app')
+BEGIN
+    DROP LOGIN [capco_app];
+END
+GO
+
 CREATE DATABASE [CapcoJordan];
 GO
 
 ALTER DATABASE [CapcoJordan] SET MULTI_USER;
 GO
 
+IF NOT EXISTS (SELECT 1 FROM sys.sql_logins WHERE name = N'capco_app')
+BEGIN
+    CREATE LOGIN [capco_app] WITH PASSWORD = N'Capco!Pass123', CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF;
+END
+GO
+
 USE [CapcoJordan];
+GO
+
+IF EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'capco_app')
+BEGIN
+    DROP USER [capco_app];
+END
+GO
+
+CREATE USER [capco_app] FOR LOGIN [capco_app] WITH DEFAULT_SCHEMA = [dbo];
+GO
+
+ALTER ROLE [db_owner] ADD MEMBER [capco_app];
 GO
 
 -- Identity core tables ----------------------------------------------------

--- a/src/Capco.Web/Program.cs
+++ b/src/Capco.Web/Program.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ??
-    "Server=WINDESKTOP\\SQLEXPRESS;Database=CapcoJordan;Trusted_Connection=True;MultipleActiveResultSets=true";
+    "Server=WINDESKTOP\\SQLEXPRESS;Database=CapcoJordan;User Id=capco_app;Password=Capco!Pass123;MultipleActiveResultSets=true;TrustServerCertificate=True";
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));

--- a/src/Capco.Web/appsettings.Development.json.sample
+++ b/src/Capco.Web/appsettings.Development.json.sample
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=WINDESKTOP\\SQLEXPRESS;Database=CapcoJordan;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=WINDESKTOP\\SQLEXPRESS;Database=CapcoJordan;User Id=capco_app;Password=Capco!Pass123;MultipleActiveResultSets=true;TrustServerCertificate=True"
   },
   "Stripe": {
     "SecretKey": "sk_test_yourkey",

--- a/src/Capco.Web/appsettings.json
+++ b/src/Capco.Web/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=WINDESKTOP\\SQLEXPRESS;Database=CapcoJordan;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
+    "DefaultConnection": "Server=WINDESKTOP\\SQLEXPRESS;Database=CapcoJordan;User Id=capco_app;Password=Capco!Pass123;MultipleActiveResultSets=true;TrustServerCertificate=True"
   },
   "Stripe": {
     "SecretKey": "sk_test_XXXXXXXXXXXXXXXXXXXX",


### PR DESCRIPTION
## Summary
- restore the SQL Server-focused startup configuration with a default connection string that uses the dedicated `capco_app` login
- drop SQLite package dependencies and reinstate SQL Server defaults in the data configuration
- update setup docs, configuration samples, and the install script to create and grant the `capco_app` login so application logins succeed

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e53517d2b883238966c173d2370ff8