### PR TITLE
Add authentication-mode guard to install script

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Capco Confectionery's e-commerce experience built with ASP.NET Core MVC, Entity 
 
 ## Database Provisioning
 
-Before running the install script, confirm that SQL Server is configured for **SQL Server and Windows Authentication mode** (mixed mode) and restart the SQL Server service if you switch modes. This allows the application-specific `capco_app` SQL login to authenticate.
+Before running the install script, confirm that SQL Server is configured for **SQL Server and Windows Authentication mode** (mixed mode) and restart the SQL Server service if you switch modes. This allows the application-specific `capco_app` SQL login to authenticate. The install script now stops with a descriptive error if the server is still configured for Windows Authentication only.
 
 The application expects the SQL Server database to be pre-provisioned. Run the install script to rebuild the schema, seed data, and create a dedicated SQL login on `WINDESKTOP\\SQLEXPRESS`:
 

--- a/docs/sql/Install_WINDESKTOP_SQLEXPRESS.sql
+++ b/docs/sql/Install_WINDESKTOP_SQLEXPRESS.sql
@@ -7,6 +7,13 @@
 USE [master];
 GO
 
+DECLARE @isIntegratedOnly INT = CONVERT(INT, SERVERPROPERTY('IsIntegratedSecurityOnly'));
+IF (@isIntegratedOnly = 1)
+BEGIN
+    THROW 51000, 'SQL Server is configured for Windows Authentication only. Enable mixed mode (SQL Server and Windows Authentication) before running this script so the capco_app login can authenticate.', 1;
+END
+GO
+
 IF DB_ID(N'CapcoJordan') IS NOT NULL
 BEGIN
     ALTER DATABASE [CapcoJordan] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;


### PR DESCRIPTION
## Summary
- prevent the install script from running when SQL Server is configured for Windows Authentication only so the capco_app login can authenticate
- document the new guard in the database provisioning instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5586456688323806610f1d3222f41