### PR TITLE
Configure EF to split queries for collection includes

### DIFF
--- a/src/Capco.Web/Program.cs
+++ b/src/Capco.Web/Program.cs
@@ -11,7 +11,10 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
     "Server=WINDESKTOP\\SQLEXPRESS;Database=CapcoJordan;User Id=capco_app;Password=Capco!Pass123;MultipleActiveResultSets=true;TrustServerCertificate=True";
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseSqlServer(connectionString));
+{
+    options.UseSqlServer(connectionString);
+    options.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+});
 
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>(options =>
     {


### PR DESCRIPTION
## Summary
- configure the Entity Framework DbContext registration to use split queries when loading multiple collections, eliminating the runtime warning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e55e891d2883239bb527b42cc31c8f