### PR TITLE
Fix SQL Server query splitting configuration

### DIFF
--- a/src/Capco.Web/Program.cs
+++ b/src/Capco.Web/Program.cs
@@ -12,8 +12,10 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
 {
-    options.UseSqlServer(connectionString);
-    options.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+    options.UseSqlServer(connectionString, sqlOptions =>
+    {
+        sqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+    });
 });
 
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>(options =>


### PR DESCRIPTION
## Summary
- configure the EF Core SQL Server registration to set query splitting via the provider-specific options builder

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e560d624a48323827eecb550d9154b